### PR TITLE
Add rows for undefined teams behavior to Annex C

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -187,14 +187,16 @@ The following cases summarize this behavior:
 \end{itemize}
 \tabularnewline
 \hline
-Concurrently using active-set-based and team-based collectives & Concurrently
-using the default team on an active-set-based collective with the default
-team in a team-based collective, for instance inside a parallel region,
-results in undefined behavior.\tabularnewline
+Concurrent use of a team & Teams are not thread-safe objects.
+Concurrent use of a team from multiple threads results in undefined
+behavior.  Such a situation can arise when one thread is calling a
+team-implicit collective (e.g., \FUNC{shmem\_barrier\_all}), which
+implicitly operate on the world team, and another calls a team-based
+collective (e.g., \FUNC{shmem\_broadcastmem}). \tabularnewline
 \hline
 Destroying a team with unfreed private contexts & Before destroying a given
-team, the user is responsible for destroying all contexts within that team
-having the \LibConstRef{SHMEM\_CTX\_PRIVATE} option enabled, otherwise, the
+team, the user is responsible for destroying all contexts created from that team
+with the \LibConstRef{SHMEM\_CTX\_PRIVATE} option enabled; otherwise, the
 behavior is undefined.\tabularnewline
 \hline
 \end{longtable}

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -160,7 +160,7 @@ accessible \acp{PE}, or may exit without a warning.\tabularnewline
 Accessing an invalid team member \ac{PE} & Passing a \ac{PE} value that
 corresponds to an invalid team member to an RMA/AMO routine, as the root of
 a broadcast, etc. results in undefined behavior.  Invalid team member
-\ac{PE} values include those that are negative or greater than the size of
+\ac{PE} values include those that are negative or greater than or equal to the size of
 the team.\tabularnewline
 \hline
 Use of non-symmetric variables & Some routines require remotely accessible

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -151,17 +151,12 @@ have already been called, any subsequent calls to these initialization routines
 result in undefined behavior.
 \tabularnewline
 \hline
-Accessing non-existent \acp{PE} & If a communications routine accesses a
-non-existent \ac{PE}, then the \openshmem library may handle this
-situation in an implementation-defined way.  For example, the library may report
-an error message saying that the \ac{PE} accessed is outside the range of
-accessible \acp{PE}, or may exit without a warning.\tabularnewline
-\hline
-Accessing an invalid team member \ac{PE} & Passing a \ac{PE} value that
-corresponds to an invalid team member to an RMA/AMO routine, as the root of
-a broadcast, etc. results in undefined behavior.  Invalid team member
-\ac{PE} values include those that are negative or greater than or equal to the size of
-the team.\tabularnewline
+Specifying invalid \ac{PE} numbers & For \openshmem routines that accept a
+\ac{PE} number as an argument, if the \ac{PE} number is invalid for the
+team associated with the operation (either implicitly or explicitly), the
+behavior is undefined.  An invalid \ac{PE} number includes those that are
+negative or greater than or equal to the size of the associated team.
+\tabularnewline
 \hline
 Use of non-symmetric variables & Some routines require remotely accessible
 variables to perform their function.  For example, a \PUT{} to a non-symmetric variable may
@@ -191,7 +186,7 @@ Concurrent use of a team & Teams are not thread-safe objects.
 Concurrent use of a team from multiple threads results in undefined
 behavior.  Such a situation can arise when one thread is calling a
 team-implicit collective (e.g., \FUNC{shmem\_barrier\_all}), which
-implicitly operate on the world team, and another calls a team-based
+implicitly operates on the world team, and another calls a team-based
 collective (e.g., \FUNC{shmem\_broadcastmem}). \tabularnewline
 \hline
 Destroying a team with unfreed private contexts & Before destroying a given

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -157,6 +157,12 @@ situation in an implementation-defined way.  For example, the library may report
 an error message saying that the \ac{PE} accessed is outside the range of
 accessible \acp{PE}, or may exit without a warning.\tabularnewline
 \hline
+Accessing an invalid team member \ac{PE} & Passing a \ac{PE} value that
+corresponds to an invalid team member to an RMA/AMO routine, as the root of
+a broadcast, etc. results in undefined behavior.  Invalid team member
+\ac{PE} values include those that are negative or greater than the size of
+the team.\tabularnewline
+\hline
 Use of non-symmetric variables & Some routines require remotely accessible
 variables to perform their function.  For example, a \PUT{} to a non-symmetric variable may
 be trapped where possible and the library may abort the program.  Another
@@ -180,6 +186,16 @@ The following cases summarize this behavior:
     \item \VAR{len} is not 0, pointer is non-null: supported.
 \end{itemize}
 \tabularnewline
+\hline
+Concurrently using active-set-based and team-based collectives & Concurrently
+using the default team on an active-set-based collective with the default
+team in a team-based collective, for instance inside a parallel region,
+results in undefined behavior.\tabularnewline
+\hline
+Destroying a team with unfreed private contexts & Before destroying a given
+team, the user is responsible for destroying all contexts within that team
+having the \LibConstRef{SHMEM\_CTX\_PRIVATE} option enabled, otherwise, the
+behavior is undefined.\tabularnewline
 \hline
 \end{longtable}
 


### PR DESCRIPTION
This PR addresses issue https://github.com/openshmem-org/specification/issues/296

I tried to capture the undefined behavior exhibited by the example in issue https://github.com/openshmem-org/specification/issues/303 in [this row here](https://github.com/davidozog/openshmem-specification/blob/sec/backmatter_undefined_teams_behavior/content/backmatter.tex#L190), but I'm not sure I got it right - does it look ok @naveen-rn / @nspark?

Also, I'm sure there are more cases of undefined behavior new to v1.5 that I haven't yet captured... please feel free to remind me of those.  (I haven't included the "otherwise invalid" teams or contexts... do we want to?)

