### PR TITLE
Elaborate active-set deprecation

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -335,26 +335,26 @@ supported before removal.
     \minitab{
         \LibConstRef{SHMEM\_SYNC\_VALUE}
         \\ \LibConstRef{SHMEM\_SYNC\_SIZE}
-        \\ \LibConstRef{SHMEM\_BCAST\_SYNC\_SIZE}
-        \\ \LibConstRef{SHMEM\_REDUCE\_SYNC\_SIZE}
         \\ \LibConstRef{SHMEM\_BARRIER\_SYNC\_SIZE}
-        \\ \LibConstRef{SHMEM\_COLLECT\_SYNC\_SIZE}
         \\ \LibConstRef{SHMEM\_ALLTOALL\_SYNC\_SIZE}
         \\ \LibConstRef{SHMEM\_ALLTOALLS\_SYNC\_SIZE}
+        \\ \LibConstRef{SHMEM\_BCAST\_SYNC\_SIZE}
+        \\ \LibConstRef{SHMEM\_COLLECT\_SYNC\_SIZE}
+        \\ \LibConstRef{SHMEM\_REDUCE\_SYNC\_SIZE}
         \\ \LibConstRef{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE}
     } & 1.5 & Current & \minitab{\hyperref[subsec:team_collectives]{Team-based collectives}} \\ \hline
     \CorCpp: Active-set-based \FuncRef{shmem\_sync}
         & 1.5 & Current & Team-based \hyperref[subsec:shmem_sync]{\FUNC{shmem\_sync}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_alltoall[32,64]} & 1.5 & Current &
+    \hyperref[subsec:shmem_alltoall]{\FUNC{shmem\_alltoall}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_alltoalls[32,64]} & 1.5 & Current &
+    \hyperref[subsec:shmem_alltoalls]{\FUNC{shmem\_alltoalls}} \\ \hline
     \CorCpp: \FuncRef{shmem\_broadcast[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_broadcast]{\FUNC{shmem\_broadcast}} \\ \hline
     \CorCpp: \FuncRef{shmem\_collect[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_collect]{\FUNC{shmem\_collect}} \\ \hline
     \CorCpp: \FuncRef{shmem\_fcollect[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_collect]{\FUNC{shmem\_fcollect}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_alltoall[32,64]} & 1.5 & Current &
-    \hyperref[subsec:shmem_alltoall]{\FUNC{shmem\_alltoall}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_alltoalls[32,64]} & 1.5 & Current &
-    \hyperref[subsec:shmem_alltoalls]{\FUNC{shmem\_alltoalls}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}
         & 1.5 & Current & \hyperref[subsec:shmem_and_reduce]{\FUNC{shmem\_and\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}
@@ -530,11 +530,11 @@ out in favor of using collective operations with a team parameter.
 The library constants
 \begin{center}
 \begin{tabular}{ll}
-    \LibConstRef{SHMEM\_SYNC\_VALUE}         & \LibConstRef{SHMEM\_COLLECT\_SYNC\_SIZE} \\
-    \LibConstRef{SHMEM\_SYNC\_SIZE}          & \LibConstRef{SHMEM\_ALLTOALL\_SYNC\_SIZE} \\
-    \LibConstRef{SHMEM\_BCAST\_SYNC\_SIZE}   & \LibConstRef{SHMEM\_ALLTOALLS\_SYNC\_SIZE} \\
-    \LibConstRef{SHMEM\_REDUCE\_SYNC\_SIZE}  & \LibConstRef{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE} \\
-    \LibConstRef{SHMEM\_BARRIER\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_SYNC\_VALUE}            & \LibConstRef{SHMEM\_BCAST\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_SYNC\_SIZE}             & \LibConstRef{SHMEM\_COLLECT\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_BARRIER\_SYNC\_SIZE}    & \LibConstRef{SHMEM\_REDUCE\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_ALLTOALL\_SYNC\_SIZE}   & \LibConstRef{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE} \\
+    \LibConstRef{SHMEM\_ALLTOALLS\_SYNC\_SIZE} \\
 \end{tabular}
 \end{center}
 were deprecated as these constants pertain only to active-set-based collectives.
@@ -546,11 +546,11 @@ replaced with the team-based \Cstd[11] \FuncRef{shmem\_sync} or \CorCpp
 The fixed-sized versions of the active-set-based routines
 \begin{center}
 \begin{tabular}{ll}
+    \FuncRef{shmem\_alltoall32} & \FuncRef{shmem\_alltoall64} \\
+    \FuncRef{shmem\_alltoalls32} & \FuncRef{shmem\_alltoalls64} \\
     \FuncRef{shmem\_broadcast32} & \FuncRef{shmem\_broadcast64} \\
     \FuncRef{shmem\_collect32} & \FuncRef{shmem\_collect64} \\
     \FuncRef{shmem\_fcollect32} & \FuncRef{shmem\_fcollect64} \\
-    \FuncRef{shmem\_alltoall32} & \FuncRef{shmem\_alltoall64} \\
-    \FuncRef{shmem\_alltoalls32} & \FuncRef{shmem\_alltoalls64} \\
 \end{tabular}
 \end{center}
 were deprecated. Instead, all team-based collective routines use standard

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -248,7 +248,9 @@ supported before removal.
     & \textbf{Replaced By} \\
     \hline
     \endhead
+    %% Deprecated in 1.1
     Header Directory: \hyperref[subsec:dep_rationale:mpp]{\HEADER{mpp}} & 1.1 & Current & (none) \\ \hline
+    %% Deprecated in 1.2
     \CorCpp: \hyperref[subsec:start_pes]{\FuncRef{start\_pes}} & 1.2 & Current & \hyperref[subsec:shmem_init]{\FUNC{shmem\_init}} \\ \hline
     \Fortran: \hyperref[subsec:start_pes]{\FuncRef{START\_PES}} & 1.2 & Current & \hyperref[subsec:shmem_init]{\FUNC{SHMEM\_INIT}} \\ \hline
     \hyperref[subsec:start_pes]{Implicit finalization} & 1.2 & Current & \hyperref[subsec:shmem_finalize]{\FUNC{shmem\_finalize}} \\ \hline
@@ -261,6 +263,7 @@ supported before removal.
     \CorCpp: \FuncRef{shrealloc} & 1.2 & Current & \hyperref[subsec:shfree]{\FUNC{shmem\_realloc}} \\ \hline
     \CorCpp: \FuncRef{shmemalign} & 1.2 & Current & \hyperref[subsec:shfree]{\FUNC{shmem\_align}} \\ \hline
     \Fortran: \FuncRef{SHMEM\_PUT} & 1.2 & Current & \hyperref[subsec:shmem_put]{\FUNC{SHMEM\_PUT8} or \FUNC{SHMEM\_PUT64}} \\ \hline
+    %% Deprecated in 1.3
     \minitab{\CorCpp: \hyperref[subsec:shmem_cache]{\FuncRef{shmem\_clear\_cache\_inv}}
         \\ \Fortran: \hyperref[subsec:shmem_cache]{\FuncRef{SHMEM\_CLEAR\_CACHE\_INV}}}
         & 1.3 & Current & (none) \\ \hline
@@ -293,6 +296,7 @@ supported before removal.
     \LibConstRef{\_SHMEM\_CMP\_LE} & 1.3 & Current & \hyperref[subsec:library_constants]{\CONST{SHMEM\_CMP\_LE}} \\ \hline
     \LibConstRef{\_SHMEM\_CMP\_GT} & 1.3 & Current & \hyperref[subsec:library_constants]{\CONST{SHMEM\_CMP\_GT}} \\ \hline
     \LibConstRef{\_SHMEM\_CMP\_GE} & 1.3 & Current & \hyperref[subsec:library_constants]{\CONST{SHMEM\_CMP\_GE}} \\ \hline
+    %% Deprecated in 1.4
     \EnvVarRef{SMA\_VERSION}         & 1.4 & Current & \hyperref[subsec:environment_variables]{\ENVVAR{SHMEM\_VERSION}} \\ \hline
     \EnvVarRef{SMA\_INFO}            & 1.4 & Current & \hyperref[subsec:environment_variables]{\ENVVAR{SHMEM\_INFO}} \\ \hline
     \EnvVarRef{SMA\_SYMMETRIC\_SIZE} & 1.4 & Current & \hyperref[subsec:environment_variables]{\ENVVAR{SHMEM\_SYMMETRIC\_SIZE}} \\ \hline
@@ -327,6 +331,7 @@ supported before removal.
         \\ \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_add}}
         & 1.4 & Current & \hyperref[subsec:shmem_atomic_add]{\FUNC{shmem\_atomic\_add}} \\ \hline
     Entire \Fortran API & 1.4 & Current & (none) \\ \hline
+    %% Deprecated in 1.5
     \minitab{
         \LibConstRef{SHMEM\_SYNC\_VALUE}
         \\ \LibConstRef{SHMEM\_SYNC\_SIZE}
@@ -338,22 +343,40 @@ supported before removal.
         \\ \LibConstRef{SHMEM\_ALLTOALLS\_SYNC\_SIZE}
         \\ \LibConstRef{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE}
     } & 1.5 & Current & \minitab{\hyperref[subsec:team_collectives]{Team-based collectives}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_barrier} & 1.5 & Current &
-    \hyperref[subsec:shmem_quiet]{\FUNC{shmem\_quiet}}; \hyperref[subsec:shmem_sync]{\FUNC{shmem\_sync}} \\ \hline
-    \CorCpp: Active set based \FuncRef{shmem\_sync} & 1.5 & Current &
-    Team based \hyperref[subsec:shmem_sync]{\FUNC{shmem\_sync}} \\ \hline
+    \CorCpp: Active-set-based \FuncRef{shmem\_sync}
+        & 1.5 & Current & Team-based \hyperref[subsec:shmem_sync]{\FUNC{shmem\_sync}} \\ \hline
     \CorCpp: \FuncRef{shmem\_broadcast[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_broadcast]{\FUNC{shmem\_broadcast}} \\ \hline
     \CorCpp: \FuncRef{shmem\_collect[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_collect]{\FUNC{shmem\_collect}} \\ \hline
     \CorCpp: \FuncRef{shmem\_fcollect[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_collect]{\FUNC{shmem\_fcollect}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_\TYPENAME\_OP\_to\_all} & 1.5 & Current &
-    \hyperref[subsec:shmem_collect]{\FUNC{shmem\_\TYPENAME\_OP\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_alltoall[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_alltoall]{\FUNC{shmem\_alltoall}} \\ \hline
     \CorCpp: \FuncRef{shmem\_alltoalls[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_alltoalls]{\FUNC{shmem\_alltoalls}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_and\_reduce}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_or\_reduce}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_xor\_reduce}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_max\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_max\_reduce}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_min\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_min\_reduce}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_sum\_reduce}} \\ \hline
+    \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_prod\_to\_all}
+        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_prod\_reduce}} \\ \hline
+    \CorCpp: \hyperref[subsec:shmem_barrier]{\FuncRef{shmem\_barrier}}
+        & 1.5 & Current & \hyperref[subsec:shmem_quiet]{\FuncRef{shmem\_quiet}} + \hyperref[subsec:shmem_sync]{\FuncRef{shmem\_sync}} \\ \hline
+    %% Deprecated in 1.6
+    %% Deprecated in 1.7
+    %% Notes
+    %% - If a hyperref spans more than one line vertically, the clickable box
+    %%   will also span more than one line. To prevent this, wrap the hyperref
+    %%   in a minitab. Example in 1.5: "Team-based collectives".
     \end{longtable}
 \end{center}
 
@@ -496,25 +519,61 @@ leverage the \openshmem Specification's \Cstd API through the
 \footnote{Formally, \Fortran[2003] is known as ISO/IEC~1539-1:2004(E).}.
 
 
-\subsection{Active-set-based collective routines}
-With the addition of \openshmem teams, the previous methods for performing collective
+\subsection{Active-set-based collectives}
+With the addition of \hyperref[subsec:team]{\openshmem teams}, the previous method for performing collective
 operations has been superseded by a more readable, flexible method for
 organizing and communicating between groups of \acp{PE}. All collective routines
 which previously indicated subgroups of \acp{PE} with a list of
-parameters to describe the subgroup composition should be phased
+parameters to describe the subgroup composition (active set) should be phased
 out in favor of using collective operations with a team parameter.
 
-When moving from active set routines to teams based routines, the fixed-size
-versions of the routines, e.g. \FUNC{shmem\_broadcast32}, were not
-carried forward. Instead, all teams based collective routines use standard
+The library constants
+\begin{center}
+\begin{tabular}{ll}
+    \LibConstRef{SHMEM\_SYNC\_VALUE}         & \LibConstRef{SHMEM\_COLLECT\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_SYNC\_SIZE}          & \LibConstRef{SHMEM\_ALLTOALL\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_BCAST\_SYNC\_SIZE}   & \LibConstRef{SHMEM\_ALLTOALLS\_SYNC\_SIZE} \\
+    \LibConstRef{SHMEM\_REDUCE\_SYNC\_SIZE}  & \LibConstRef{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE} \\
+    \LibConstRef{SHMEM\_BARRIER\_SYNC\_SIZE} \\
+\end{tabular}
+\end{center}
+were deprecated as these constants pertain only to active-set-based collectives.
+
+The \CorCpp active-set-based \FuncRef{shmem\_sync} routine was deprecated and
+replaced with the team-based \Cstd[11] \FuncRef{shmem\_sync} or \CorCpp
+\FuncRef{shmem\_team\_sync} routine.
+
+The fixed-sized versions of the active-set-based routines
+\begin{center}
+\begin{tabular}{ll}
+    \FuncRef{shmem\_broadcast32} & \FuncRef{shmem\_broadcast64} \\
+    \FuncRef{shmem\_collect32} & \FuncRef{shmem\_collect64} \\
+    \FuncRef{shmem\_fcollect32} & \FuncRef{shmem\_fcollect64} \\
+    \FuncRef{shmem\_alltoall32} & \FuncRef{shmem\_alltoall64} \\
+    \FuncRef{shmem\_alltoalls32} & \FuncRef{shmem\_alltoalls64} \\
+\end{tabular}
+\end{center}
+were deprecated. Instead, all team-based collective routines use standard
 \Cstd types with the option to use generic \textit{C11} functions for more portable
 and maintainable implementations.
+
+The active-set-based reduction routines
+\begin{center}
+\begin{tabular}{ll}
+    \FuncRef{shmem\_\FuncParam{TYPENAME}\_and\_to\_all} & \FuncRef{shmem\_\FuncParam{TYPENAME}\_max\_to\_all} \\
+    \FuncRef{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}  & \FuncRef{shmem\_\FuncParam{TYPENAME}\_min\_to\_all} \\
+    \FuncRef{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all} & \FuncRef{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all} \\
+                                                        & \FuncRef{shmem\_\FuncParam{TYPENAME}\_prod\_to\_all} \\
+\end{tabular}
+\end{center}
+were deprecated and replaced with team-based reduction routines.
+
 
 \subsection{\CorCpp: \FUNC{shmem\_barrier}}
 Each \openshmem team might
 be associated with some number of communication contexts. The \FUNC{shmem\_barrier}
-functions imply that the default context is quiesced after synchronizing
-some set of \acp{PE}. Since teams may have some number of contexts associated
+function implies that the default context is quiesced after synchronizing
+some active set of \acp{PE}. Since teams may have some number of contexts associated
 with the team, it becomes less clear which context would be the ``default'' context
 for that particular team. Rather than continue to support \FUNC{shmem\_barrier}
 for active-sets or teams, programs should use a call to \FUNC{shmem\_quiet}

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -356,19 +356,19 @@ supported before removal.
     \CorCpp: \FuncRef{shmem\_alltoalls[32,64]} & 1.5 & Current &
     \hyperref[subsec:shmem_alltoalls]{\FUNC{shmem\_alltoalls}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_and\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_and_reduce]{\FUNC{shmem\_and\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_or\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_or_reduce]{\FUNC{shmem\_or\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_xor\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_xor_reduce]{\FUNC{shmem\_xor\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_max\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_max\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_max_reduce]{\FUNC{shmem\_max\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_min\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_min\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_min_reduce]{\FUNC{shmem\_min\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_sum\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_sum_reduce]{\FUNC{shmem\_sum\_reduce}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_prod\_to\_all}
-        & 1.5 & Current & \hyperref[subsec:shmem_reductions]{\FUNC{shmem\_\FuncParam{TYPENAME}\_prod\_reduce}} \\ \hline
+        & 1.5 & Current & \hyperref[subsec:shmem_prod_reduce]{\FUNC{shmem\_prod\_reduce}} \\ \hline
     \CorCpp: \hyperref[subsec:shmem_barrier]{\FuncRef{shmem\_barrier}}
         & 1.5 & Current & \hyperref[subsec:shmem_quiet]{\FuncRef{shmem\_quiet}} + \hyperref[subsec:shmem_sync]{\FuncRef{shmem\_sync}} \\ \hline
     %% Deprecated in 1.6

--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -19,6 +19,7 @@ operations performed by a group of \acp{PE}.
 \end{enumerate}
 
 \subsubsection*{Team-based collectives}
+\label{subsec:team_collectives}
 
 The team-based collective routines are performed with respect to a valid
 \openshmem team, which is specified by a team handle argument.

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -33,6 +33,7 @@
 
 
 \paragraph{AND}
+\label{subsec:shmem_and_reduce}
 Performs a bitwise AND reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -56,6 +57,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}@(TYPE *dest, const TY
 where \TYPE{} is one of the integer types supported for the AND operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
 \paragraph{OR}
+\label{subsec:shmem_or_reduce}
 Performs a bitwise OR reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -79,6 +81,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}@(TYPE *dest, const TYP
 where \TYPE{} is one of the integer types supported for the OR operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
 \paragraph{XOR}
+\label{subsec:shmem_xor_reduce}
 Performs a bitwise exclusive OR (XOR) reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -102,6 +105,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all}@(TYPE *dest, const TY
 where \TYPE{} is one of the integer types supported for the XOR operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
 \paragraph{MAX}
+\label{subsec:shmem_max_reduce}
 Performs a maximum-value reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -126,6 +130,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_max\_to\_all}@(TYPE *dest, const TY
 where \TYPE{} is one of the integer or real types supported for the MAX operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
 \paragraph{MIN}
+\label{subsec:shmem_min_reduce}
 Performs a minimum-value reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -150,6 +155,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_min\_to\_all}@(TYPE *dest, const TY
 where \TYPE{} is one of the integer or real types supported for the MIN operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
 \paragraph{SUM}
+\label{subsec:shmem_sum_reduce}
 Performs a sum reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -174,6 +180,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all}@(TYPE *dest, const TY
 where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
 \paragraph{PROD}
+\label{subsec:shmem_prod_reduce}
 Performs a product reduction across a set of \acp{PE}.\newline
 
 %% C11


### PR DESCRIPTION
This PR requires/includes branch **deprecate-active-set-constants-375** (#6).

Clean up the deprecation table and rationale entries for the active-set collectives.

- Explicitly expand reduction operations
- Reorder deprecation table entries to match ordering of rationale entries
- Replace semi-colon in Replacement for shmem_barrier with plus-sign
- Add new labels for subsec:team_collectives and the reductions
- Misc changes
    - Add headers into Deprecation Table
    - Grammatical word-smithing