### PR TITLE
Convert bad use of \textit

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -496,7 +496,7 @@ out in favor of using collective operations with a team parameter.
 When moving from active set routines to teams based routines, the fixed-size
 versions of the routines, e.g. \FUNC{shmem\_broadcast32}, were not
 carried forward. Instead, all teams based collective routines use standard
-\Cstd types with the option to use generic \textit{C11} functions for more portable
+\Cstd types with the option to use generic \Cstd[11] functions for more portable
 and maintainable implementations.
 
 \subsection{\CorCpp: \FUNC{shmem\_barrier}}

--- a/content/profiling_interface.tex
+++ b/content/profiling_interface.tex
@@ -8,7 +8,7 @@ tools for \openshmem will have access to the source code that
 implements \openshmem on any particular machine. It is, therefore,  
 necessary to provide a mechanism by which the implementors of such 
 tools can collect whatever performance information they wish 
-\textit{without} access to the underlying implementation.
+\emph{without} access to the underlying implementation.
 
 The \openshmem profiling interface places the following requirements 
 on implementations. 


### PR DESCRIPTION
Nitpick. Bad use of `\textit`. Replaced with `\emph` or existing macros.