### PR TITLE
Use `{ .. }` sets instead of `[ ... ]` optionals

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -360,15 +360,15 @@ supported before removal.
     } & 1.5 & Current & Team-based collectives, \minitab{Section~\ref{subsec:team_collectives}}. \\ \hline
     \CorCpp: Active-set-based \FuncRef{shmem\_sync}
         & 1.5 & Current & Team-based \hyperref[subsec:shmem_sync]{\FUNC{shmem\_sync}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_alltoall[32,64]} & 1.5 & Current &
+    \CorCpp: \FuncRef{shmem\_alltoall\{32, 64\}} & 1.5 & Current &
     \hyperref[subsec:shmem_alltoall]{\FUNC{shmem\_alltoall}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_alltoalls[32,64]} & 1.5 & Current &
+    \CorCpp: \FuncRef{shmem\_alltoalls\{32, 64\}} & 1.5 & Current &
     \hyperref[subsec:shmem_alltoalls]{\FUNC{shmem\_alltoalls}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_broadcast[32,64]} & 1.5 & Current &
+    \CorCpp: \FuncRef{shmem\_broadcast\{32, 64\}} & 1.5 & Current &
     \hyperref[subsec:shmem_broadcast]{\FUNC{shmem\_broadcast}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_collect[32,64]} & 1.5 & Current &
+    \CorCpp: \FuncRef{shmem\_collect\{32, 64\}} & 1.5 & Current &
     \hyperref[subsec:shmem_collect]{\FUNC{shmem\_collect}} \\ \hline
-    \CorCpp: \FuncRef{shmem\_fcollect[32,64]} & 1.5 & Current &
+    \CorCpp: \FuncRef{shmem\_fcollect\{32, 64\}} & 1.5 & Current &
     \hyperref[subsec:shmem_collect]{\FUNC{shmem\_fcollect}} \\ \hline
     \CorCpp: \FuncRef{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}
         & 1.5 & Current & \hyperref[subsec:shmem_and_reduce]{\FUNC{shmem\_and\_reduce}} \\ \hline


### PR DESCRIPTION
Change entries in the deprecation table to use `{ ... }` sets instead of `[ ... ]` optionals.