### PR TITLE
Changelog for #334 removal of short and unsigned short from wait_until/test

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -636,6 +636,9 @@ The following list describes the specific changes in \openshmem[1.5]:
 %
 \item Removed \FUNC{SHMEM\_CACHE}.
 %
+\item Deprecated \CTYPE{short} and \CTYPE{unsigned short} variants for
+\FUNC{shmem\_wait\_until} and \FUNC{shmem\_test}.
+%
 \item Added \FUNC{shmem\_malloc\_with\_hints} interface and corresponding hints
 \CONST{SHMEM\_MALLOC\_ATOMICS\_REMOTE} and \CONST{SHMEM\_MALLOC\_SIGNAL\_REMOTE}.
 \\ See Section \ref{subsec:shmmallochint} and \ref{subsec:library_constants}.

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -692,6 +692,8 @@ all \acp{PE}, including the root \ac{PE}.
 \item Added support for nonblocking \OPR{put-with-signal} functions.
 \\ See Section \ref{subsec:shmem_put_signal_nbi}.
 %
+\item Deprecated Table~\ref{p2psynctypes}: point-to-point synchronization types and names.
+%
 \item Clarified that point-to-point synchronization routines preserve the
   atomicity of OpenSHMEM \acp{AMO}.
 \\ See Section~\ref{subsec:amo_guarantees}.


### PR DESCRIPTION
cc https://github.com/openshmem-org/specification/issues/334
Closes https://github.com/openshmem-org/specification/issues/411

https://github.com/naveen-rn/specification/pull/3 has two main changes to document in the changelog:
1. deprecation of short and unsigned short variants from `shmem_wait_until` and `shmem_test`
2. deprecation of Table 10: p2p sync types and names

The second doesn't need to be called out explicitly, but it doesn't hurt because I called it out near where the clarification of atomic guarantees effected this deprecation.

Need reviews: @davidozog @jamesaross @swpoole