### PR TITLE
Changelog 276 304

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -683,6 +683,9 @@ all \acp{PE}, including the root \ac{PE}.
   \ref{subsec:shmem_broadcast}, \ref{subsec:shmem_collect},
   and \ref{subsec:shmem_reductions}.
 %
+\item Clarified interoperability of \openshmem with other programming models.
+\\ See Annex~\ref{sec:interoperability}.
+%
 \item Clarified restrictions on using pointers to symmetric objects.
 \\ See Sections
   \ref{subsec:pointers_to_symmetric_objects} and

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -683,6 +683,11 @@ all \acp{PE}, including the root \ac{PE}.
   \ref{subsec:shmem_broadcast}, \ref{subsec:shmem_collect},
   and \ref{subsec:shmem_reductions}.
 %
+\item Clarified restrictions on using pointers to symmetric objects.
+\\ See Sections
+  \ref{subsec:pointers_to_symmetric_objects} and
+  \ref{subsec:invoking_openshmem_operations}.
+%
 \item Added support for nonblocking \ac{AMO} functions.
 \\ See Section \ref{sec:amo-nbi}.
 %

--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -60,7 +60,7 @@ that \ac{PE} next engages in an \openshmem call.
   performance value for \openshmem programs.
 }
 
-\subsection{Invoking OpenSHMEM Operations}
+\subsection{Invoking OpenSHMEM Operations}\label{subsec:invoking_openshmem_operations}
 
 Pointer arguments to \openshmem routines that point to non-const data must not
 overlap in memory with other arguments to the same \openshmem operation, with

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -42,7 +42,7 @@ objects and private data objects.  As shown, symmetric data objects can be
 located either in the symmetric heap or in the global/static memory section of
 each \ac{PE}.
 
-\subsection{Pointers to Symmetric Objects}
+\subsection{Pointers to Symmetric Objects}\label{subsec:pointers_to_symmetric_objects}
 
 Symmetric data objects are referenced in \openshmem operations through the
 local pointer to the desired remotely accessible object.  The address contained


### PR DESCRIPTION
Adds two missing changelog entries for
- openshmem-org/specification#276 - Clarifications for symmetric pointers (@jdinan)
- openshmem-org/specification#304 - Rework of Annex D interoperability (@minsii)

Need reviews: @davidozog @jamesaross @swpoole etc.