### PR TITLE
Misc backmatter changes

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -213,6 +213,7 @@ clusters, and InfiniBand-based clusters.
     \item Cray was acquired by \ac{SGI} in 1996
     \item Cray was acquired by Tera in 2000 (MTA)
     \item Platforms: Cray T3D, T3E, C90, J90, SV1, SV2, X1, X2, XE, XMT, XT
+    \item \ac{HPE} acquired \ac{SGI} in 2019
     \end{itemize}
   \item \ac{SGI} SHMEM
     \begin{itemize}

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -240,9 +240,9 @@ A listing of \openshmem implementations can be found on
 
 
 
-\chapter{OpenSHMEM Specification and Deprecated API}\label{sec:dep_api}
+\chapter{OpenSHMEM Specification and Deprecated API}\label{sec:dep}
 
-\section{Overview}\label{subsec:dep_overview}
+\section{Overview}\label{dep:overview}
 \TableIndex{Deprecated API}
 For the \openshmem Specification, deprecation is the process of identifying
 API that is supported but no longer recommended for use by users.
@@ -264,7 +264,7 @@ supported before removal.
     \hline
     \endhead
     %% Deprecated in 1.1
-    Header Directory: \hyperref[subsec:dep_rationale:mpp]{\HEADER{mpp}} & 1.1 & Current & (none) \\ \hline
+    Header Directory: \hyperref[dep:mpp_header]{\HEADER{mpp}} & 1.1 & Current & (none) \\ \hline
     %% Deprecated in 1.2
     \CorCpp: \hyperref[subsec:start_pes]{\FuncRef{start\_pes}} & 1.2 & Current & \hyperref[subsec:shmem_init]{\FUNC{shmem\_init}} \\ \hline
     \Fortran: \hyperref[subsec:start_pes]{\FuncRef{START\_PES}} & 1.2 & 1.4 & \hyperref[subsec:shmem_init]{\FUNC{SHMEM\_INIT}} \\ \hline
@@ -411,10 +411,10 @@ supported before removal.
     \end{longtable}
 \end{center}
 
-\section{Deprecation Rationale}\label{subsec:dep_rationale}
+\section{Deprecation Rationale}\label{dep:rationale}
 
 \subsection{Header Directory: \HEADER{mpp}}
-\label{subsec:dep_rationale:mpp}
+\label{dep:mpp_header}
 In addition to the default system header paths, \openshmem implementations
 must provide all \openshmem-specified header files from the \HEADER{mpp}
 header directory such that these headers can be referenced in \CorCpp as
@@ -817,11 +817,11 @@ The following list describes the specific changes in \openshmem[1.4]:
 \item Clarified ordering semantics of memory ordering, point-to-point synchronization, and collective
 synchronization routines.
 %
-\item Clarified deprecation overview and added deprecation rationale in Annex F.
-\\See Section \ref{sec:dep_api}.
+\item Clarified deprecation overview and added deprecation rationale.
+\\ See Sections~\ref{dep:overview} and \ref{dep:rationale}.
 %
 \item Deprecated header directory \HEADER{mpp}.
-\\See Section \ref{sec:dep_api}.
+\\ See Section~\ref{dep:mpp_header}.
 %
 \item Deprecated the \FUNC{shmem\_wait} functions and the \CTYPE{long}-typed \CorCpp \FUNC{shmem\_wait\_until} function.
 \\ See Section \ref{subsec:p2p_intro}.
@@ -1007,9 +1007,9 @@ The following list describes the specific changes in \openshmem[1.2]:
 \item Undefined behavior for null pointers without zero counts added.
 \\See Annex \ref{sec:undefined}
 %
-\item Addition of new Annex for clearly specifying deprecated API and its
+\item Added new Annex for clearly specifying deprecated API and its
       support across versions of the \openshmem Specification.
-\\See Annex \ref{sec:dep_api}.
+\\See Annex \ref{sec:dep}.
 %
 \end{itemize}
 
@@ -1056,7 +1056,7 @@ The following list describes the specific changes in \openshmem[1.1]:
 \\See Section \ref{subsec:shmem_pe_accessible} and \ref{subsec:shmem_addr_accessible}.
 %
 \item Added an annex on interoperability with \ac{MPI}.
-\\See Annex D.
+\\See Annex~\ref{sec:interoperability}.
 %
 \item Added examples to the different interfaces.
 %

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -660,14 +660,14 @@ all \acp{PE}, including the root \ac{PE}.
   \FUNC{shmem\_team\_split\_strided},
   \FUNC{shmem\_team\_split\_2d}, and
   \FUNC{shmem\_team\_destroy}.
-\\ See Sections
-  \ref{subsec:shmem_team_my_pe},
-  \ref{subsec:shmem_team_n_pes},
-  \ref{subsec:shmem_team_get_config},
-  \ref{subsec:shmem_team_translate_pe},
-  \ref{subsec:shmem_team_split_strided},
-  \ref{subsec:shmem_team_split_2d}, and
-  \ref{subsec:shmem_team_destroy}.
+\ChangelogRef{
+  subsec:shmem_team_my_pe,
+  subsec:shmem_team_n_pes,
+  subsec:shmem_team_get_config,
+  subsec:shmem_team_translate_pe,
+  subsec:shmem_team_split_strided,
+  subsec:shmem_team_split_2d,
+  subsec:shmem_team_destroy}%
 %
 \item Added team-based communication-management functions:
   \FUNC{shmem\_team\_create\_ctx} and
@@ -804,7 +804,7 @@ The following list describes the specific changes in \openshmem[1.4]:
 \FUNC{shmem\_wait} routines and the \VAR{lock} arguments in the lock API.
 \emph{Rationale: Volatile qualifiers were added to several API routines in
 \openshmem[1.3]; however, they were later found to be unnecessary.}
-\\ See Sections \ref{subsec:shmem_wait_until} and \ref{subsec:shmem_lock}.
+\ChangelogRef{subsec:shmem_wait_until, subsec:shmem_lock}%
 %
 \item Deprecated the \VAR{SMA\_}* environment variables and added equivalent
 \VAR{SHMEM\_}* environment variables.
@@ -818,7 +818,7 @@ The following list describes the specific changes in \openshmem[1.4]:
 synchronization routines.
 %
 \item Clarified deprecation overview and added deprecation rationale.
-\\ See Sections~\ref{dep:overview} and \ref{dep:rationale}.
+\ChangelogRef{dep:overview, dep:rationale}%
 %
 \item Deprecated header directory \HEADER{mpp}.
 \\ See Section~\ref{dep:mpp_header}.

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -9,6 +9,7 @@
 \fancyhead[RO, LE]{\thepage}
 \fancyfoot[CE, CO]{\thepage}
 \renewcommand{\headrulewidth}{0pt}
+\renewcommand{\thesection}{\thesectionOrig}
 
 
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -224,7 +224,7 @@ clusters, and InfiniBand-based clusters.
     \item \ac{SGI} was acquired by Rackable Systems in 2009
     \item \ac{SGI} and \ac{OSSS} signed a
       SHMEM trademark licensing agreement in 2010
-    \item \ac{HPE} acquired {SGI} in 2016
+    \item \ac{HPE} acquired \ac{SGI} in 2016
     \end{itemize}
   \end{itemize}
 \end{itemize}

--- a/content/frontmatter.tex
+++ b/content/frontmatter.tex
@@ -27,6 +27,7 @@
 \fancyhead[RE, LO]{\rightmark}
 \fancyhead[RO, LE]{\thepage}
 \renewcommand{\headrulewidth}{0pt}
+\let\thesectionOrig\thesection % Used by backmatter to restore Annex numbering.
 \renewcommand{\thesection}{\arabic{section}}
 
 { %using setlength to force standardized spacing, if needed

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -9,6 +9,7 @@
 
 \renewcommand{\chaptername}{Chapter}
 \renewcommand{\appendixname}{Annex}
+\Crefname{appendix}{Annex}{Annexes}
 
 % Place some penalty for doing the break
 % The penalty for a ``\gb'' should be greater than a \hyphenpenalty.
@@ -119,6 +120,18 @@
 \acro{HPE}{Hewlett Packard Enterprise}
 \end{acronym}
 
+% Remove whitespace and retain commas when using cleveref's `\cref`.
+% https://tex.stackexchange.com/a/340502 by users/16967/heiko-oberdiek
+\makeatletter
+\let\org@@cref\@cref
+% Modify cleveref's internal \@cref to zap spaces between list elements.
+\renewcommand*{\@cref}[2]{%
+  \edef\process@me{%
+    \noexpand\org@@cref{#1}{\zap@space#2 \@empty}%
+  }\process@me
+}
+\makeatother
+\newcommand{\ChangelogRef}[1]{\\See \Cref{#1}.}
 
 % Grab current listings style for use in environment escape to LaTeX.
 % https://tex.stackexchange.com/a/209644 by users/21891/jub0bs

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -121,7 +121,7 @@
 
 
 % Grab current listings style for use in environment escape to LaTeX.
-% https://tex.stackexchange.com/a/209644
+% https://tex.stackexchange.com/a/209644 by users/21891/jub0bs
 \makeatletter
 \newcommand\ListingsCurrentStyle{}
 \lst@AddToHook{Output}{\global\let\ListingsCurrentStyle\lst@thestyle}

--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -56,3 +56,4 @@
 \usepackage{caption}
 \usepackage{subcaption}
 \usepackage{csquotes}
+\usepackage{cleveref}


### PR DESCRIPTION
In particular, https://github.com/BryantLam/openshmem-specification/pull/21/commits/b6a1f0e5ff39a200220c69e892ebce6cf971ca3b is a neat change to make the changelog references more uniform. I haven't applied it everywhere yet, primarily because formally reading all those changes is painful. I'd rather execute this edit as an out-of-band whole-document edit.